### PR TITLE
fix: expand homedir and env variables in pathing

### DIFF
--- a/command_utils.py
+++ b/command_utils.py
@@ -41,9 +41,10 @@ but is built in for future use.
 
 __author__ = "Mark van de Streek"
 __date__ = "2024-11-01"
-__all__ = ["ShellCommand", "CommandInvoker", "Command"]
+__all__ = ["ShellCommand", "CommandInvoker", "Command", "normalize_path"]
 
 import logging
+import os
 import shlex
 import subprocess
 from abc import ABC, abstractmethod
@@ -51,6 +52,19 @@ from pathlib import Path
 from typing import IO, Any, Tuple
 
 from preprocessing.exceptions.command_utils_exceptions import SubprocessError
+
+
+def normalize_path(path: str) -> str:
+    """
+    Expand user home (~) and environment variables in a file path.
+    ----------
+    Input:
+        - path: string with the file path (may contain ~ or env variables, e.g., $HOME)
+    Output:
+        - str: Path with ~ and environment variables expanded to absolute path
+    ----------
+    """
+    return os.path.expandvars(os.path.expanduser(path))
 
 
 class Command(ABC):

--- a/parsing/read_config_pattern.py
+++ b/parsing/read_config_pattern.py
@@ -29,6 +29,7 @@ from typing import Any
 
 import yaml
 
+from command_utils import normalize_path
 from preprocessing.exceptions.parsing_exceptions import YAMLLoadingError, YAMLStructureError
 from preprocessing.exceptions.snp_detection_exceptions import IncorrectSNPConfiguration, PathError, PointFinderScriptError
 
@@ -212,9 +213,9 @@ class ReadConfigPattern:
         """
         logging.debug("Creating database from config file...")
         self.creation_dict = {
-            "database_path": self.pattern["database"]["path"],
+            "database_path": normalize_path(self.pattern["database"]["path"]),
             "database_name": self.pattern["database"]["name"],
-            "input_fasta_file": self.pattern["database"]["target_genes_file"],
+            "input_fasta_file": normalize_path(self.pattern["database"]["target_genes_file"]),
             "database_type": self.input_file_type,
             "file_type": self.input_file_type,
         }
@@ -226,7 +227,7 @@ class ReadConfigPattern:
         that will return the required parameters.
         These getter functions also validate the variables.
         """
-        self.creation_dict["path_snps"] = self.pattern["database"]["path_snps"]
+        self.creation_dict["path_snps"] = normalize_path(self.pattern["database"]["path_snps"])
         self.creation_dict["species"] = self.pattern["database"]["species"]
         self.creation_dict["method"] = "blastn" if self.input_file_type == "FASTA" else "kma"
         self.creation_dict["method_path"] = self.get_method_path()
@@ -257,10 +258,11 @@ class ReadConfigPattern:
         If the directory already exists, it returns the path to the directory.
         ----------
         Output:
-            - str: Path to the output directory
+            - str: Path to the output directory (~ and $HOME are expanded)
         ----------
         """
         path: str = self.pattern["global_settings"]["run_output_snps"]
+        path = normalize_path(path)  # ? Expand ~ and environment variables
         path = path if path.endswith("/") else f"{path}/"
         if not os.path.exists(path) or not os.path.isdir(path):
             os.makedirs(path, exist_ok=True)
@@ -274,10 +276,11 @@ class ReadConfigPattern:
         before usage.
         ----------
         Output:
-            - str: Path to the PointFinder script
+            - str: Path to the PointFinder script (it will expand ~ and env variables)
         ----------
         """
         path: str = self.pattern["metadata"]["pointfinder_script_path"]
+        path = normalize_path(path)  # ? Expand ~ and environment variables
         if path.endswith("PointFinder.py"):
             return path
         logging.error("The PointFinder script is incorrectly specified or missing in the config file, exiting...")
@@ -445,6 +448,7 @@ class ReadConfigPattern:
                 is not found
         ----------
         """
+        target_snps_file = normalize_path(target_snps_file)
         if os.path.exists(target_snps_file):
             return target_snps_file
         logging.error("PointFinder genes file %s not found, exiting...", target_snps_file)

--- a/preprocessing/validation/validating_input_arguments.py
+++ b/preprocessing/validation/validating_input_arguments.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import yaml
 
+from command_utils import normalize_path
 from preprocessing.exceptions.validation_exceptions import (
     FileNotExistsError,
     InvalidFileExtensionError,
@@ -67,7 +68,8 @@ class ArgsValidator:
         self.config = None
         self.config = None
         self.get_config_input()
-        self.input_file_list: list[str] = self.option["input_file_list"]
+        # ? Normalize all input file paths (expand ~ and environment (e.g., $HOME) variables)
+        self.input_file_list: list[str] = [normalize_path(file) for file in self.option["input_file_list"]]
 
     def validate_file_extensions(self, file: str) -> bool:
         """

--- a/queries/snp_query_runnner.py
+++ b/queries/snp_query_runnner.py
@@ -25,7 +25,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from command_utils import CommandInvoker, ShellCommand
+from command_utils import CommandInvoker, ShellCommand, normalize_path
 from queries.base_query_runner import BaseQueryRunner
 from queries.pointfinder_runner import PointFinder
 
@@ -63,6 +63,7 @@ class SNPQueryRunner(BaseQueryRunner):
         ----------
         """
         super().__init__(run_options)
+        self.run_options["pointfinder_script_path"] = normalize_path(self.run_options["pointfinder_script_path"])
         self.check_pointfinder_existence(self.run_options["pointfinder_script_path"])
         self.query = PointFinder.get_query(option=self.run_options)
         self.version_command = PointFinder.get_version_command()
@@ -103,6 +104,7 @@ class SNPQueryRunner(BaseQueryRunner):
             - path: Path to the PointFinder script
         ----------
         """
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
         if not os.path.isfile(path):
             logging.info("PointFinder script not found, downloading...")
             CommandInvoker(


### PR DESCRIPTION
For the pipeline we don't know which user or functional-account runs it, hence I usually implement the config paths to the user's homedir via `~` pathing. This wasn't handled properly by Pacini but this PR should fix it. Moreover, this also handles ENV vars (e.g., `$HOME`). I've successfully tested both `~` and `$HOME` variables for the following keys in the config yaml: `pointfinder_script_path`, `target_genes_file`, `target_snps_file` and `path_snps`.